### PR TITLE
remove monkey patching of Kernel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Timeloop [![Code Climate](https://codeclimate.com/github/pinoss/timeloop.png)](https://codeclimate.com/github/pinoss/timeloop) [![Build Status](https://travis-ci.org/pinoss/timeloop.svg?branch=master)](https://travis-ci.org/pinoss/timeloop) [![Coverage Status](https://coveralls.io/repos/pinoss/timeloop/badge.png?branch=master)](https://coveralls.io/r/pinoss/timeloop?branch=master) [![Gem Version](https://badge.fury.io/rb/timeloop.svg)](http://badge.fury.io/rb/timeloop)
 
-Timeloop is a simple Ruby gem that provides loop with time interval inspired on 'every' method from whenever gem. 
+Timeloop is a simple Ruby gem that provides loop with time interval inspired on 'every' method from whenever gem.
 
 ## Installation
 
@@ -23,7 +23,7 @@ Require gem in you Ruby file:
 ```ruby
 require 'timeloop'
 
-every 10.seconds do
+Timeloop.every 10.seconds do
   puts '10 seconds delay'
 end
 
@@ -34,7 +34,7 @@ end
 # 10 seconds delay
 # ...
 
-every 3.hours do
+Timeloop.every 3.hours do
   Mail.deliver do
     from    'me@test.email'
     to      'you@test.email'
@@ -43,7 +43,7 @@ every 3.hours do
   end
 end
 
-every :minute do
+Timeloop.every :minute do
   product = 2 * 2
   puts "and 2 * 2 is still #{product}"
 end
@@ -59,7 +59,7 @@ end
 You can also specify how many times your block will be evaluated:
 
 ```ruby
-every 10.seconds, maximum: 4.times do |i|
+Timeloop.every 10.seconds, maximum: 4.times do |i|
  puts i
 end
 
@@ -71,7 +71,7 @@ end
 # 3
 # => 4
 
-every 'second', maximum: 3 do |i|
+Timeloop.every 'second', maximum: 3 do |i|
  puts 'You will see me only 3 times.'
 end
 
@@ -81,6 +81,21 @@ end
 # You will see me only 3 times.
 # You will see me only 3 times.
 # => 3
+```
+
+If you want to include the `every` method in your own classes simply
+include the `Timeloop::Helper` module.
+
+```ruby
+class MyClass
+  include Timeloop::Helper
+
+  def doit
+    every 10.seconds, max: 4 do |i|
+      puts i
+    end
+  end
+end
 ```
 
 ## Contributing

--- a/lib/timeloop.rb
+++ b/lib/timeloop.rb
@@ -1,11 +1,10 @@
 require 'timeloop/core_ext'
 require 'timeloop/version'
 
-# Provides a way to execute a block of code periodically. The
-# runtime of the block is taken in to account so a delay in one run
-# does not impact the start times of future runs.
+# Execute a block of code periodically. The runtime of the block is
+# taken in to account so a delay in one run does not impact the start
+# times of future runs.
 class Timeloop
-
   # Runs provided block periodically.
   #
   # Yields Integer index of the iteration to the provide block every `period`.
@@ -24,6 +23,7 @@ class Timeloop
     end
   end
 
+  # Returns string representation of self,
   def to_s
     ["#<Timeloop period=#{period}",
      max < Float::INFINITY ? ", max=#{max}" : "",
@@ -34,6 +34,16 @@ class Timeloop
 
   attr_reader :period, :max, :logger
 
+  # Initialize a new Timeloop object.
+  #
+  # Options
+  #   period  - seconds or name of time period (eg, 'second', 'hour')
+  #             between iterations
+  #   max     - the maximum number of executions of the block. Default:
+  #             INFINITY
+  #   maximum - synonym of `max`
+  #   logger  - logger to which debugging info should be sent. Default:
+  #             no logging
   def initialize(opts)
     @period = parse_frequency(opts.fetch(:period))
     @max    = parse_maximum_value(opts.fetch(:maximum){opts.fetch(:max, Float::INFINITY)})
@@ -61,7 +71,7 @@ class Timeloop
       frequency
     when :second, 'second'
       1.second
-    when :minute, 'second'
+    when :minute, 'minute'
       1.minute
     when :hour, 'hour'
       1.hour
@@ -80,23 +90,30 @@ class Timeloop
   NULL_LOGGER = Class.new do
     def debug(*args); end
   end.new
-end
 
-module Kernel
-  # Provides a way to execute a block of code periodically. The
-  # runtime of the block is taken in to account so a delay in one run
-  # does not impact the start times of future runs.
-  #
-  # Yields Integer index of the iteration to the provide block every `period`.
-  def every(period, opts = {}, &blk)
-    Timeloop.new(opts.merge(period: period)).loop(&blk)
+  # Conveniences methods that provide access to the Timeloop
+  # functionality to be included in other classes and modules.
+  module Helper
+    # Provides a way to execute a block of code periodically. The
+    # runtime of the block is taken in to account so a delay in one run
+    # does not impact the start times of future runs.
+    #
+    # Arguments
+    #   period - seconds or name of time period (eg,
+    #            'second', 'hour') between iterations
+    #
+    # Options
+    #   max     - the maximum number of executions of the block. Default:
+    #             INFINITY
+    #   maximum - synonym of `max`
+    #   logger  - logger to which debugging info should be sent. Default:
+    #             no logging
+    #
+    # Yields Integer index of the iteration to the provide block every `period`.
+    def every(period, opts = {}, &blk)
+      Timeloop.new(opts.merge(period: period)).loop(&blk)
+    end
   end
 
-  private
-
-
-end
-
-class Object
-  include Kernel
+  extend Helper
 end


### PR DESCRIPTION
Doing so reduces risk of conflicts with other gems and make the client
code simpler to understand.

This will, obviously, require a major version bump since it removes the `every` method from kernel.
